### PR TITLE
Adds preprocessors and line feed trimming

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var matchers = require('./matchers');
 var knownTypes = Object.keys(matchers);
 var toBuffer = require('typedarray-to-buffer');
+var processors = require('./processors');
 
 /**
   # binary-type
@@ -27,6 +28,9 @@ function matches(mimetype, buffer) {
   if (! Buffer.isBuffer(buffer)) {
     buffer = toBuffer(buffer);
   }
+
+  // Run the buffer through the preprocessors
+  buffer = processors(buffer);
 
   passedChecks = checks && checks.filter(function(check) {
     return check(buffer);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Using file signatures attempt to determine the mime-type of a buffer",
   "main": "index.js",
   "scripts": {
-    "test": "node test/all.js && browserify test/all.js -t brfs | testling -x ./node_modules/travis-multirunner/start-$BROWSER.sh",
+    "test": "node test/all.js && browserify test/all.js -t brfs | testling -x ./node_modules/travis-multirunner/start.sh",
     "gendocs": "gendocs > README.md",
     "viewfile": "cat test/helpers/$FILENAME | od -tx1 | less"
   },
@@ -27,7 +27,7 @@
     "browserify": "^10.2.4",
     "tape": "^4.0.0",
     "testling": "^1.7.1",
-    "travis-multirunner": "^2.5.0"
+    "travis-multirunner": "^3.0.0"
   },
   "dependencies": {
     "typedarray-to-buffer": "^3.0.1"

--- a/processors.js
+++ b/processors.js
@@ -5,22 +5,22 @@ var LINE_FEED = 10;
   (ie. Bitcoin wallet file), then it should just start checking from the bytes after the feed
  **/
 function trimLineFeeds(buffer) {
-	if (!buffer || !Buffer.isBuffer(buffer) || buffer.length <= 0) return buffer;
+  if (!buffer || !Buffer.isBuffer(buffer) || buffer.length <= 0) return buffer;
 
-	// Trim all line feeds from the start of the buffer
-	var idx = 0;
-	while (idx < buffer.length) {
-		if (buffer[idx] !== LINE_FEED) break;
-		idx++;
-	}
+  // Trim all line feeds from the start of the buffer
+  var idx = 0;
+  while (idx < buffer.length) {
+    if (buffer[idx] !== LINE_FEED) break;
+    idx++;
+  }
 
-	// Return the trimmed buffer
-	return (idx === 0 ? buffer : buffer.slice(idx, buffer.length));
+  // Return the trimmed buffer
+  return (idx === 0 ? buffer : buffer.slice(idx, buffer.length));
 }
 
 var processors = [trimLineFeeds];
 module.exports = function(buffer) {
-	return processors.reduce(function(memo, processor) {
-		return processor(memo);
-	}, buffer);
+  return processors.reduce(function(memo, processor) {
+    return processor(memo);
+  }, buffer);
 };

--- a/processors.js
+++ b/processors.js
@@ -1,0 +1,26 @@
+var LINE_FEED = 10;
+
+/**
+  Removes unnecessary line feeds from the start of a buffer. If a file signature expects a line feed
+  (ie. Bitcoin wallet file), then it should just start checking from the bytes after the feed
+ **/
+function trimLineFeeds(buffer) {
+	if (!buffer || !Buffer.isBuffer(buffer) || buffer.length <= 0) return buffer;
+
+	// Trim all line feeds from the start of the buffer
+	var idx = 0;
+	while (idx < buffer.length) {
+		if (buffer[idx] !== LINE_FEED) break;
+		idx++;
+	}
+
+	// Return the trimmed buffer
+	return (idx === 0 ? buffer : buffer.slice(idx, buffer.length));
+}
+
+var processors = [trimLineFeeds];
+module.exports = function(buffer) {
+	return processors.reduce(function(memo, processor) {
+		return processor(memo);
+	}, buffer);
+};

--- a/test/helpers/helloworld_linefeed.pdf
+++ b/test/helpers/helloworld_linefeed.pdf
@@ -1,0 +1,69 @@
+
+%PDF-1.7
+
+1 0 obj  % entry point
+<<
+  /Type /Catalog
+  /Pages 2 0 R
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /Pages
+  /MediaBox [ 0 0 200 200 ]
+  /Count 1
+  /Kids [ 3 0 R ]
+>>
+endobj
+
+3 0 obj
+<<
+  /Type /Page
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F1 4 0 R
+    >>
+  >>
+  /Contents 5 0 R
+>>
+endobj
+
+4 0 obj
+<<
+  /Type /Font
+  /Subtype /Type1
+  /BaseFont /Times-Roman
+>>
+endobj
+
+5 0 obj  % page content
+<<
+  /Length 44
+>>
+stream
+BT
+70 50 TD
+/F1 12 Tf
+(Hello, world!) Tj
+ET
+endstream
+endobj
+
+xref
+0 6
+0000000000 65535 f
+0000000010 00000 n
+0000000079 00000 n
+0000000173 00000 n
+0000000301 00000 n
+0000000380 00000 n
+trailer
+<<
+  /Size 6
+  /Root 1 0 R
+>>
+startxref
+492
+%%EOF

--- a/test/helpers/testfiles.js
+++ b/test/helpers/testfiles.js
@@ -7,5 +7,6 @@ module.exports = {
   jpeg2: fs.readFileSync(__dirname + '/github-avatar.jpg'),
   png: fs.readFileSync(__dirname + '/Open_Source_Media_Framework_Logo.png'),
   pdf: fs.readFileSync(__dirname + '/helloworld.pdf'),
+  pdfLineFeed: fs.readFileSync(__dirname + '/helloworld_linefeed.pdf'),
   ogg: fs.readFileSync(__dirname + '/Mudchute_cow_1.ogg')
 };

--- a/test/match.js
+++ b/test/match.js
@@ -32,6 +32,11 @@ test('pdf test file matches application/pdf', function(t) {
   t.ok(binaryType.matches('application/pdf', testFiles.pdf), 'recognised application/pdf');
 });
 
+test('pdf test file with extra line feed matches application/pdf', function(t) {
+  t.plan(1);
+  t.ok(binaryType.matches('application/pdf', testFiles.pdfLineFeed), 'recognised application/pdf');
+});
+
 test('ogg test file matches audio/ogg', function(t) {
   t.plan(1);
   t.ok(binaryType.matches('audio/ogg', testFiles.ogg), 'recognised audio/ogg');


### PR DESCRIPTION
Had an error with a PDF file not being properly detected because for some reason it had empty line feeds at the beginning of the file before the `%PDF` signature.

This adds preprocessors that are run over the buffer prior to it being used to run a check - the first being a `trimLineFeeds` function that removes these empty line feeds.

From looking at the list of file signatures, I don't think removing the line feeds should cause any harmful side effects.
