### PR TITLE
Prevent checking of the JPEG trailer

### DIFF
--- a/datablocks.js
+++ b/datablocks.js
@@ -10,7 +10,7 @@ module.exports = {
   image: {
     bmp: [ '42 4D' ],
     gif: [ '47 49 46 38 39 61', '00 3B' ], // gif89a at the moment
-    jpeg: ['FF D8 FF', 'FF D9' ],
+    jpeg: ['FF D8 FF' ],
     png: [ '89 50 4E 47 0D 0A 1A 0A', '49 45 4E 44 AE 42 60 82' ]
   },
 


### PR DESCRIPTION
This removes checking of the JPEG trailer code, and instead relies solely on the 3 byte header for JPEGs.

Primarily this is due to having encountered some JPEGs in the wild that are missing the trailer code. Not sure whether ignoring the trailer altogether is the best approach though, so no worries if you don't want to merge this in.